### PR TITLE
fix: 로그인 응답토큰 추가 및 글작성 API JWT 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/demo/domain/member/member/dto/MemberJoinReqBody.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/MemberJoinReqBody.java
@@ -1,4 +1,4 @@
-package com.ll.demo.domain.member.member.controller;
+package com.ll.demo.domain.member.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/ll/demo/domain/quote/controller/QuoteController.java
+++ b/src/main/java/com/ll/demo/domain/quote/controller/QuoteController.java
@@ -6,6 +6,8 @@ import com.ll.demo.domain.quote.service.QuoteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,9 +20,24 @@ public class QuoteController {
 
     private final QuoteService quoteService;
 
+    /**
+     * 글 작성 (최종 저장) API
+     * [POST] /api/quotes
+     * JWT 토큰이 필요합니다.
+     */
     @PostMapping
-    public ResponseEntity<QuoteResponse> createQuote(@RequestBody QuoteCreateRequest request) {
-        QuoteResponse response = quoteService.createQuote(request);
+    public ResponseEntity<QuoteResponse> createQuote(
+            @RequestBody QuoteCreateRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        // 1. 토큰에서 사용자 ID 추출 (프로젝트 설정에 따라 user.getUsername() 형식이 다를 수 있음)
+        Long authorId = Long.valueOf(user.getUsername());
+
+        // 2. Service 호출
+        // ★ 중요: Service의 createQuote(Long authorId, String content) 순서에 맞춰서 값을 넘겨줍니다.
+        QuoteResponse response = quoteService.createQuote(authorId, request.getContent());
+
+        // 3. 결과 반환
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/ll/demo/domain/quote/dto/QuoteCreateRequest.java
+++ b/src/main/java/com/ll/demo/domain/quote/dto/QuoteCreateRequest.java
@@ -8,7 +8,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class QuoteCreateRequest {
-    // 실제 서비스에서는 토큰에서 추출하겠지만, API 테스트를 위해 일단 입력받습니다.
-    private Long authorId;
     private String content;
 }

--- a/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
@@ -1,6 +1,5 @@
 package com.ll.demo.domain.quote.service;
 
-import com.ll.demo.domain.quote.dto.QuoteCreateRequest;
 import com.ll.demo.domain.quote.dto.QuoteResponse;
 import com.ll.demo.domain.quote.entity.Quote;
 import com.ll.demo.domain.quote.repository.QuoteRepository;
@@ -21,15 +20,16 @@ public class QuoteService {
 
     private final QuoteRepository quoteRepository;
 
+    // ★ Controller에서 authorId와 content를 따로 넘겨주므로, 여기서도 따로 받아야 합니다.
     @Transactional
-    public QuoteResponse createQuote(QuoteCreateRequest request) {
+    public QuoteResponse createQuote(Long authorId, String content) {
         // 1. 1일 1Quote 제한 체크
-        validateOneQuotePerDay(request.getAuthorId());
+        validateOneQuotePerDay(authorId);
 
         // 2. 저장
         Quote quote = Quote.builder()
-                .authorId(request.getAuthorId())
-                .content(request.getContent())
+                .authorId(authorId)
+                .content(content)
                 .build();
 
         Quote savedQuote = quoteRepository.save(quote);

--- a/src/main/java/com/ll/demo/global/security/SecurityConfig.java
+++ b/src/main/java/com/ll/demo/global/security/SecurityConfig.java
@@ -10,8 +10,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @RequiredArgsConstructor
@@ -30,8 +28,6 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/api/*/members", "/api/*/members/login")
                                 .permitAll()
                                 .requestMatchers(HttpMethod.DELETE, "/api/*/members/logout")
-                                .permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/quotes")
                                 .permitAll()
                                 .requestMatchers("/h2-console/**")
                                 .permitAll()


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #12 

## 📢 작업 내용 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- (프론트엔드) 관련 와이어프레임 또는 프로토타입 이미지
- (백엔드) 관련 기능 명세서 링크 or 간략히 설명 
- 명언 작성(Quote) API 구현: JWT 인증을 적용하여 로그인한 유저만 글을 작성할 수 있도록 하고, '1일 1명언 작성' 제한 로직을 구현했습니다.
- 로그인 API 개선: 프론트엔드에서의 토큰 관리 편의성을 위해, 로그인 성공 시 응답 본문(Body)에 accessToken을 포함하여 반환하도록 수정했습니다.


## ✨ Changes

1. 로그인 응답 구조 변경 (ApiV1MemberController)

기존에는 Access Token을 쿠키(Cookie)로만 발급했으나, LoginResponseBody DTO를 신설하여 JSON 응답 바디에도 토큰이 포함되도록 리팩토링했습니다.

2. 글 작성 API 보안 강화 (QuoteController)

클라이언트가 요청 바디(Request Body)에 authorId를 직접 보내는 방식을 제거했습니다.

대신 @AuthenticationPrincipal을 사용하여 JWT 토큰에서 파싱된 유저 정보를 통해 작성자를 식별하도록 변경하여 보안을 강화했습니다.

3. 서비스 계층 리팩토링 (QuoteService)

Controller의 변경 사항에 맞춰 createQuote 메서드가 (Long authorId, String content)를 파라미터로 받도록 수정했습니다.

existsByAuthorIdAndCreateDateBetween를 사용하여 하루에 하나의 글만 쓸 수 있는 유효성 검사 로직을 적용했습니다.




## 📷 스크린샷 (선택)
- 스크린샷, 시연 영상
<img width="933" height="849" alt="image" src="https://github.com/user-attachments/assets/f41cfa0a-bfdf-4d91-ad3b-6611de6bb381" />



## 💬 리뷰 요구사항 (선택)
- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
