### PR TITLE
feat:명언좋아요기능구현

### DIFF
--- a/src/main/java/com/ll/demo/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/demo/domain/member/member/entity/Member.java
@@ -1,14 +1,22 @@
 package com.ll.demo.domain.member.member.entity;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.ll.demo.global.jpa.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
-import lombok.*;
-
-import static lombok.AccessLevel.PROTECTED;
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @Entity
 @Table(name = "members")
@@ -44,4 +52,13 @@ public class Member extends BaseTime {
 
     @Column(nullable = true, length = 255)
     private String refreshToken;
+
+    public String getUsername() {
+        return this.email;
+    }
+
+    // 2. 시큐리티가 "권한(authorities) 주세요" 하면 "일반 유저(ROLE_USER)"라고 답합니다.
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
 }

--- a/src/main/java/com/ll/demo/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/ll/demo/domain/member/member/service/MemberService.java
@@ -4,12 +4,11 @@ import com.ll.demo.domain.member.member.entity.Member;
 import com.ll.demo.domain.member.member.repository.MemberRepository;
 import com.ll.demo.global.exceptions.GlobalException;
 import com.ll.demo.global.rsData.RsData;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -60,4 +59,10 @@ public class MemberService {
     public boolean checkPassword(Member member, String rawPassword) {
         return passwordEncoder.matches(rawPassword, member.getPassword());
     }
+
+    public Optional<Member> findById(long id) {
+        return memberRepository.findById(id);
+    }
+
+
 }

--- a/src/main/java/com/ll/demo/domain/quote/entity/Quote.java
+++ b/src/main/java/com/ll/demo/domain/quote/entity/Quote.java
@@ -43,4 +43,6 @@ public class Quote {
         this.content = content;
         this.authorId = authorId;
     }
+
+
 }

--- a/src/main/java/com/ll/demo/domain/quote/entity/QuoteLike.java
+++ b/src/main/java/com/ll/demo/domain/quote/entity/QuoteLike.java
@@ -1,0 +1,27 @@
+package com.ll.demo.domain.quote.entity;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class QuoteLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Quote quote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    // 생성자 메서드
+    public QuoteLike(Quote quote, Member member) {
+        this.quote = quote;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/ll/demo/domain/quote/repository/QuoteLikeRepository.java
+++ b/src/main/java/com/ll/demo/domain/quote/repository/QuoteLikeRepository.java
@@ -1,0 +1,16 @@
+package com.ll.demo.domain.quote.repository;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.quote.entity.Quote;
+import com.ll.demo.domain.quote.entity.QuoteLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QuoteLikeRepository extends JpaRepository<QuoteLike, Long> {
+    // 특정 명언에 특정 멤버가 좋아요를 눌렀는지 확인
+    boolean existsByQuoteAndMember(Quote quote, Member member);
+
+    // 좋아요 취소를 위해 데이터 조회
+    Optional<QuoteLike> findByQuoteAndMember(Quote quote, Member member);
+}

--- a/src/main/java/com/ll/demo/global/security/SecurityUser.java
+++ b/src/main/java/com/ll/demo/global/security/SecurityUser.java
@@ -1,0 +1,19 @@
+package com.ll.demo.global.security;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class SecurityUser extends User {
+    private final Member member;
+
+    public SecurityUser(Member member, String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        // 부모 클래스(User)의 생성자 호출 (아이디, 비번, 권한)
+        super(username, password, authorities);
+        this.member = member;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #15 


## 📢 작업 내용 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- (프론트엔드) 관련 와이어프레임 또는 프로토타입 이미지
- (백엔드) 관련 기능 명세서 링크 or 간략히 설명 
- 명언 좋아요 등록 및 삭제 기능을 구현

## ✨ Changes
- 어떤 부분이 어떻게 바뀌었는지 작성해 주세요.
- 기능을 어떻게 구현했는지 구체적으로 설명해 주세요.

1. 도메인 영역 (Domain) - 데이터 & 로직
- QuoteLike.java (Entity)
Member와 Quote 사이의 다대다 관계를 해소하는 연결 엔티티 생성.
누가(Member), 어떤 글(Quote)을 좋아했는지 기록.

- QuoteLikeRepository.java
existsByQuoteAndMember: 중복 좋아요 방지용 조회 메서드 추가.
findByQuoteAndMember: 좋아요 취소 시 데이터 조회용 메서드 추가.

- QuoteService.java
likeQuote(): 좋아요 저장 로직 구현 (중복 체크 포함).
unlikeQuote(): 좋아요 삭제 로직 구현.

-MemberService.java
findById(): 시큐리티 필터에서 회원 정보를 조회하기 위해 추가.

2. 프레젠테이션 영역 (Controller) - API 연결
- QuoteController.java
POST /api/quotes/{id}/like: 좋아요 등록 엔드포인트 추가.
DELETE /api/quotes/{id}/like: 좋아요 취소 엔드포인트 추가.

-createQuote (글 작성): 기존에 user.getUsername()을 숫자로 파싱 하던 코드를 SecurityUser를 통해 안전하게 ID를 가져오도록 수정.

3. 글로벌/보안 영역 (Security)
- SecurityUser.java
스프링 시큐리티의 기본 User 대신, 우리 프로젝트의 Member 객체를 통째로 들고 다니는 커스텀 유저 클래스 생성.

-CustomAuthenticationFilter.java
JWT 토큰 검증 후, 단순 User 객체가 아닌 DB에서 조회한 Member 정보를 담은 SecurityUser를 생성하여 Authentication에 저장하도록 로직 변경.
예외 처리(orElseThrow) 구체화.

-Member.java (Entity)
getUsername(): 시큐리티 연동을 위해 이메일을 반환하도록 메서드 추가.
getAuthorities(): 권한(ROLE_USER)을 반환하도록 메서드 추가.


## 📷 스크린샷 (선택)
- 스크린샷, 시연 영상



## 💬 리뷰 요구사항 (선택)
- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
- 프로토타입내에서는 좋아요 개수를 반환하는 기능은 보이지않아서 단순 등록 및 삭제 기능만 구현했습니다.
