### PR TITLE
feat: 메인 화면 글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/ll/demo/domain/quote/controller/QuoteController.java
+++ b/src/main/java/com/ll/demo/domain/quote/controller/QuoteController.java
@@ -12,11 +12,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+import org.springframework.data.domain.Sort;
+
 
 @RestController
 @RequestMapping("/api/quotes")
@@ -70,4 +74,12 @@ public class QuoteController {
         quoteService.unlikeQuote(securityUser.getMember(), quoteId);
         return ResponseEntity.ok().build();
     }
+
+    // 글 목록 조회
+    @GetMapping
+    public ResponseEntity<List<QuoteResponse>> getQuotes() {
+        List<QuoteResponse> response = quoteService.getQuoteList();
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 
 @Service
 @RequiredArgsConstructor
@@ -73,5 +75,13 @@ public class QuoteService {
 
         quoteLikeRepository.findByQuoteAndMember(quote, member)
                 .ifPresent(quoteLikeRepository::delete);
+    }
+
+    // 글 목록 조회 메서드 - mj
+    public List<QuoteResponse> getQuoteList() {
+        List<Quote> quotes = quoteRepository.findAll(Sort.by(Sort.Direction.DESC, "createDate"));
+        return quotes.stream()
+                .map(QuoteResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- # 17


## 📢 작업 내용 
- 메인 화면에 필요한 글 목록 조회 기능을 구현
https://www.notion.so/2ad5da46ab658091bfa0c2a411b20000


## ✨ Changes
- QuoteService에 getQuoteList() 메서드 추가
- QuoteController에 GET /api/quotes 엔드포인트 추가

## 💬 리뷰 요구사항 
.
