### PR TITLE
feat: 친구 검색 및 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ll/demo/domain/member/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/ll/demo/domain/member/member/controller/ApiV1MemberController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor

--- a/src/main/java/com/ll/demo/domain/member/member/dto/FriendResponse.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/FriendResponse.java
@@ -1,0 +1,23 @@
+package com.ll.demo.domain.member.member.dto;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendResponse {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+    private String email;
+
+    public static FriendResponse of(Member member) {
+        return FriendResponse.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .profileImage(member.getProfileImage())
+                .email(member.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/ll/demo/domain/member/member/dto/MemberDto.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/MemberDto.java
@@ -3,6 +3,7 @@ package com.ll.demo.domain.member.member.dto;
 import com.ll.demo.domain.member.member.entity.Member;
 import lombok.Getter;
 import java.time.LocalDateTime;
+import lombok.Builder;
 
 @Getter
 public class MemberDto {

--- a/src/main/java/com/ll/demo/domain/member/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/MemberSearchResponse.java
@@ -1,0 +1,24 @@
+package com.ll.demo.domain.member.member.dto;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class MemberSearchResponse {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+    private String email;
+    // 추후 친구 정보 추가?
+    public static MemberSearchResponse of(Member member) {
+        return MemberSearchResponse.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .profileImage(member.getProfileImage())
+                .email(member.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/ll/demo/domain/member/member/dto/ProfileResponse.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/ProfileResponse.java
@@ -1,0 +1,25 @@
+package com.ll.demo.domain.member.member.dto;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileResponse {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String introduction;
+    private String profileImage; // 프로필 사진 URL
+
+    public static ProfileResponse of(Member member) {
+        return ProfileResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .profileImage(member.getProfileImage())
+                .build();
+    }
+}

--- a/src/main/java/com/ll/demo/domain/member/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/ProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ll.demo.domain.member.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ProfileUpdateRequest {
+    private String nickname;
+    private String introduction;
+    private MultipartFile profileImage;
+}

--- a/src/main/java/com/ll/demo/domain/member/member/entity/Friendship.java
+++ b/src/main/java/com/ll/demo/domain/member/member/entity/Friendship.java
@@ -1,0 +1,29 @@
+package com.ll.demo.domain.member.member.entity;
+
+import com.ll.demo.global.jpa.entity.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "friendships")
+public class Friendship extends BaseTime {
+    // 나
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    // 친구
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "friend_id")
+    private Member friend;
+
+    // 이후 상태 추가
+
+    @Builder
+    public Friendship(Member member, Member friend) {
+        this.member = member;
+        this.friend = friend;
+    }
+}

--- a/src/main/java/com/ll/demo/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/demo/domain/member/member/entity/Member.java
@@ -3,6 +3,8 @@ package com.ll.demo.domain.member.member.entity;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.ll.demo.global.jpa.entity.BaseTime;
+import com.ll.demo.global.jpa.entity.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -10,13 +12,15 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import java.util.Collection;
 import java.util.List;
+import java.time.LocalDateTime;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @Entity
 @Table(name = "members")
@@ -32,7 +36,7 @@ public class Member extends BaseTime {
     private String email;
 
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-    @Column(nullable = false)  // 비밀번호는 필수
+    @Column(nullable = false)
     private String password;
 
     @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
@@ -43,12 +47,12 @@ public class Member extends BaseTime {
     @Column(nullable = false)
     private String birthYear;
 
-    @Column(length = 255)  // 프로필 사진 - 일단 URL
+    @Column(length = 255)
     private String profileImage;
 
     @Size(max = 30, message = "자기소개는 30자 이내로 작성해주세요.")
-    @Column(length = 255)
-    private String bio;
+    @Column(nullable = true)
+    private String introduction;
 
     @Column(nullable = true, length = 255)
     private String refreshToken;
@@ -57,7 +61,7 @@ public class Member extends BaseTime {
         return this.email;
     }
 
-    // 2. 시큐리티가 "권한(authorities) 주세요" 하면 "일반 유저(ROLE_USER)"라고 답합니다.
+    // 시큐리티 - 권한
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }

--- a/src/main/java/com/ll/demo/domain/member/member/repository/FriendshipRepository.java
+++ b/src/main/java/com/ll/demo/domain/member/member/repository/FriendshipRepository.java
@@ -1,0 +1,10 @@
+package com.ll.demo.domain.member.member.repository;
+
+import com.ll.demo.domain.member.member.entity.Friendship;
+import com.ll.demo.domain.member.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+    List<Friendship> findAllByMember(Member member);
+}

--- a/src/main/java/com/ll/demo/domain/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/demo/domain/member/member/repository/MemberRepository.java
@@ -2,9 +2,23 @@ package com.ll.demo.domain.member.member.repository;
 
 import com.ll.demo.domain.member.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
+import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email); // 이메일? 아이디?
     Optional<Member> findByRefreshToken(String refreshToken);
+
+    // 닉네임 또는 이메일 - 전체 검색으로만 추출되므로 삭제
+    // List<Member> findByNicknameContainingOrEmailContaining(String nicknameKeyword, String emailKeyword);
+    // 부분 검색
+    @Query("""
+        SELECT m FROM Member m 
+        WHERE LOWER(m.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        OR LOWER(m.email) LIKE LOWER(CONCAT(:keyword, '@%')) 
+        OR LOWER(m.email) LIKE LOWER(CONCAT('%', :keyword, '@%'))
+    """)
+    List<Member> searchMembersByNicknameOrEmailUsername(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/ll/demo/domain/quote/controller/QuoteController.java
+++ b/src/main/java/com/ll/demo/domain/quote/controller/QuoteController.java
@@ -1,5 +1,6 @@
 package com.ll.demo.domain.quote.controller;
 
+import com.ll.demo.domain.member.member.entity.Member;
 import com.ll.demo.domain.quote.dto.AiSummaryReq;
 import com.ll.demo.domain.quote.dto.QuoteCreateRequest;
 import com.ll.demo.domain.quote.dto.QuoteResponse;

--- a/src/main/java/com/ll/demo/domain/quote/dto/QuoteResponse.java
+++ b/src/main/java/com/ll/demo/domain/quote/dto/QuoteResponse.java
@@ -2,6 +2,7 @@ package com.ll.demo.domain.quote.dto;
 
 import com.ll.demo.domain.quote.entity.Quote;
 import java.time.LocalDateTime;
+import lombok.Builder;
 
 public record QuoteResponse(
         Long id,

--- a/src/main/java/com/ll/demo/domain/quote/entity/Quote.java
+++ b/src/main/java/com/ll/demo/domain/quote/entity/Quote.java
@@ -12,7 +12,9 @@ import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -32,10 +34,11 @@ public class Quote extends BaseTime {
     @Column(columnDefinition = "TEXT")
     private String originalContent; // 원본 일기 내용
 
-    // 생성자에서 Member를 받아서 author 필드에 넣습니다.
-    public Quote(Member author, String content, String originalContent) {
-        this.author = author;
-        this.content = content;
-        this.originalContent = originalContent;
-    }
+    // @AllArgsConstructor 사용으로 제거했습니다 - mj
+//    // 생성자에서 Member를 받아서 author 필드에 넣습니다.
+//    public Quote(Member author, String content, String originalContent) {
+//        this.author = author;
+//        this.content = content;
+//        this.originalContent = originalContent;
+//    }
 }

--- a/src/main/java/com/ll/demo/domain/quote/entity/QuoteTagRequest.java
+++ b/src/main/java/com/ll/demo/domain/quote/entity/QuoteTagRequest.java
@@ -1,3 +1,25 @@
+package com.ll.demo.domain.quote.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.EntityListeners;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.annotation.CreatedDate;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.quote.entity.Quote;
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/ll/demo/domain/quote/repository/QuoteTagRequestRepository.java
+++ b/src/main/java/com/ll/demo/domain/quote/repository/QuoteTagRequestRepository.java
@@ -1,9 +1,9 @@
 package com.ll.demo.domain.quote.repository;
 
-import com.ll.demo.domain.quote.entity.Quote;
-import com.ll.demo.domain.member.member.entity.Member;
-import com.ll.demo.domain.quote.entity.QuoteTagRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.quote.entity.Quote;
+import com.ll.demo.domain.quote.entity.QuoteTagRequest;
 
 public interface QuoteTagRequestRepository extends JpaRepository<QuoteTagRequest, Long> {
     // 중복 요청 방지

--- a/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
@@ -7,12 +7,15 @@ import com.ll.demo.domain.quote.entity.Quote;
 import com.ll.demo.domain.quote.entity.QuoteLike;
 import com.ll.demo.domain.quote.repository.QuoteLikeRepository;
 import com.ll.demo.domain.quote.repository.QuoteRepository;
+import com.ll.demo.domain.quote.repository.QuoteTagRequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import com.ll.demo.domain.quote.entity.QuoteTagRequest;
+import com.ll.demo.domain.quote.repository.QuoteTagRequestRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -108,7 +111,7 @@ public class QuoteService {
 
         // 자기 글에 요청하는지 체크
         // 지금은 임시로 ID로 비교한다 가정
-        if (requester.getId().equals(quote.getAuthorId())) {
+        if (requester.getId().equals(quote.getAuthor().getId())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "본인 글에는 태그 요청을 할 수 없습니다.");
         }
 

--- a/src/main/java/com/ll/demo/domain/settings/controller/SettingsController.java
+++ b/src/main/java/com/ll/demo/domain/settings/controller/SettingsController.java
@@ -1,0 +1,71 @@
+package com.ll.demo.domain.settings.controller;
+
+import com.ll.demo.domain.member.member.dto.ProfileResponse;
+import com.ll.demo.domain.member.member.dto.ProfileUpdateRequest;
+import com.ll.demo.domain.member.member.service.MemberService;
+import com.ll.demo.global.security.SecurityUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import com.ll.demo.domain.member.member.dto.FriendResponse;
+import com.ll.demo.domain.member.member.entity.Member;
+import java.util.List;
+import org.springframework.web.bind.annotation.RequestParam;
+import com.ll.demo.domain.member.member.dto.MemberSearchResponse;
+
+@RestController
+@RequestMapping("/api/settings")
+@RequiredArgsConstructor
+public class SettingsController {
+
+    private final MemberService memberService;
+
+    // 내 프로필 조회
+    @GetMapping("/profile")
+    public ResponseEntity<ProfileResponse> getProfile(
+            @AuthenticationPrincipal Member member
+    ) {
+        Long memberId = member.getId();
+        ProfileResponse response = memberService.getProfile(memberId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 프로필 수정
+    @PutMapping("/profile")
+    public ResponseEntity<Void> updateProfile(
+            // 프로필 이미지 포함 - @ModelAttribute 사용
+            @ModelAttribute ProfileUpdateRequest request,
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        Long memberId = securityUser.getMember().getId();
+        memberService.updateProfile(memberId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 친구 검색 - !재검토 필요! 그룹명으로도 검색 가능하도록 service 수정
+    @GetMapping("/search")
+    public ResponseEntity<List<MemberSearchResponse>> searchMembers(
+            @RequestParam(name = "keyword") String keyword,
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        Long memberId = securityUser.getMember().getId();
+        List<MemberSearchResponse> response = memberService.searchMembers(keyword, memberId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 친구 목록
+    @GetMapping("/friends-list")
+    public ResponseEntity<List<FriendResponse>> getFriendsAndGroups(
+            @AuthenticationPrincipal Member member
+    ) {
+        Long memberId = member.getId();
+
+        List<FriendResponse> response = memberService.getFriendList(memberId);
+
+        return ResponseEntity.ok(response);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #22 


## 📢 작업 내용 
- 태그 기능 구현 위해 친구 검색 및 친구 목록 조회 먼저 구현


## ✨ Changes
- 닉네임 또는 이메일의 부분 검색으로 회원을 검색하는 기능 구현
- 로그인한 사용자의 친구 관계 조회하여 목록으로 반환하는 기능 구현(테스트 전)


## 📷 스크린샷 (선택)
- 스크린샷, 시연 영상



## 💬 리뷰 요구사항 (선택)
- 친구 목록 조회가 테스트 불가여서 로직을 꼼꼼히 읽고 피드백 주시면 감사하겠습니다!
