### PR TITLE
feat: 프로필 작성, 조회, 수정

### DIFF
--- a/src/main/java/com/ll/demo/domain/friendship/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/ll/demo/domain/friendship/friendship/repository/FriendshipRepository.java
@@ -13,4 +13,6 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     boolean existsByMemberAndFriend(Member member, Member friend);
     // 받은 친구 요청 목록 조회
     List<Friendship> findByFriendAndStatus(Member friend, FriendshipStatus status);
+    //친구 수
+    long countByMember(Member member);
 }

--- a/src/main/java/com/ll/demo/domain/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/demo/domain/member/member/repository/MemberRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email); // 이메일? 아이디?
     Optional<Member> findByRefreshToken(String refreshToken);
+    Optional<Member> findByNickname(String nickname);
 
     // 닉네임 또는 이메일 - 전체 검색으로만 추출되므로 삭제
     // List<Member> findByNicknameContainingOrEmailContaining(String nicknameKeyword, String emailKeyword);

--- a/src/main/java/com/ll/demo/domain/profile/profile/controller/ProfileController.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/controller/ProfileController.java
@@ -1,0 +1,34 @@
+package com.ll.demo.domain.profile.profile.controller;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.profile.profile.dto.ProfileResponse;
+import com.ll.demo.domain.profile.profile.dto.ProfileUpdateRequest;
+import com.ll.demo.domain.profile.profile.service.ProfileService;
+import com.ll.demo.global.security.SecurityUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/profile")
+@RequiredArgsConstructor
+public class ProfileController {
+    private final ProfileService profileService;
+
+    @GetMapping("")
+    public ResponseEntity<ProfileResponse> getMyProfile(
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        return ResponseEntity.ok(profileService.getMyProfile(securityUser.getMember()));
+    }
+
+    @PostMapping("")
+    public ResponseEntity<ProfileResponse> updateProfile(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @Valid @RequestBody ProfileUpdateRequest request
+    ) {
+        return ResponseEntity.ok(profileService.updateProfile(securityUser.getMember(), request));
+    }
+}

--- a/src/main/java/com/ll/demo/domain/profile/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/dto/ProfileResponse.java
@@ -1,0 +1,25 @@
+package com.ll.demo.domain.profile.profile.dto;
+
+import com.ll.demo.domain.member.member.entity.Member;
+
+public record ProfileResponse(
+        Long id,
+        String email,
+        String nickname,
+        String introduction,
+        String profileImage,
+        long quoteCount,
+        long friendCount
+) {
+    public static ProfileResponse from(Member member, long quoteCount, long friendCount) {
+        return new ProfileResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getIntroduction(),
+                member.getProfileImage(),
+                quoteCount,
+                friendCount
+        );
+    }
+}

--- a/src/main/java/com/ll/demo/domain/profile/profile/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/dto/ProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ll.demo.domain.profile.profile.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record ProfileUpdateRequest(
+        @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
+        String nickname,
+
+        @Size(max = 30, message = "자기소개는 30자 이내로 작성해주세요.")
+        String introduction,
+
+        String profileImage
+) {}

--- a/src/main/java/com/ll/demo/domain/profile/profile/service/ProfileService.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/service/ProfileService.java
@@ -1,0 +1,48 @@
+package com.ll.demo.domain.profile.profile.service;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.member.member.repository.MemberRepository;
+import com.ll.demo.domain.quote.repository.QuoteRepository;
+import com.ll.demo.domain.friendship.friendship.repository.FriendshipRepository;
+import com.ll.demo.domain.profile.profile.dto.ProfileResponse;
+import com.ll.demo.domain.profile.profile.dto.ProfileUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProfileService {
+    private final MemberRepository memberRepository;
+    private final QuoteRepository quoteRepository;
+    private final FriendshipRepository friendshipRepository;
+
+    // 프로필 정보 조회
+    @Transactional(readOnly = true)
+    public ProfileResponse getMyProfile(Member member) {
+        long quoteCount = quoteRepository.countByAuthor(member);
+        long friendCount = friendshipRepository.countByMember(member);
+        return ProfileResponse.from(member, quoteCount, friendCount);
+    }
+
+    // 프로필 정보 수정
+    public ProfileResponse updateProfile(Member member, ProfileUpdateRequest request) {
+        Member persistentMember = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        if (request.nickname() != null && !request.nickname().equals(persistentMember.getNickname())) {
+            memberRepository.findByNickname(request.nickname())
+                    .ifPresent(m -> { throw new IllegalArgumentException("이미 사용 중인 닉네임입니다."); });
+        }
+
+        // 객체 정보 수정
+        persistentMember.setNickname(request.nickname());
+        persistentMember.setIntroduction(request.introduction());
+        persistentMember.setProfileImage(request.profileImage());
+        // memberRepository.save(persistentMember);
+
+        return getMyProfile(persistentMember);
+    }
+}

--- a/src/main/java/com/ll/demo/domain/quote/repository/QuoteRepository.java
+++ b/src/main/java/com/ll/demo/domain/quote/repository/QuoteRepository.java
@@ -5,6 +5,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import com.ll.demo.domain.member.member.entity.Member;
 import org.springframework.data.jpa.repository.Query;
 
 public interface QuoteRepository extends JpaRepository<Quote, Long> {
@@ -17,6 +18,8 @@ public interface QuoteRepository extends JpaRepository<Quote, Long> {
     // 1일 1명언 체크용
     boolean existsByAuthorIdAndCreateDateBetween(Long authorId, LocalDateTime start, LocalDateTime end);
 
+    // 명언 개수
+    long countByAuthor(Member author);
     @Query("select ql.quote from QuoteLike ql where ql.member.id = :memberId order by ql.id desc")
     List<Quote> findQuotesLikedByMember(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #34 


## 📢 작업 내용 
- 로그인한 사용자 프로필 정보(닉네임, 자기소개, 이미지) 조회 및 수정 기능 구현
- 데이터가 유실되지 않도록 영속성 컨텍스트 처리 완료


## ✨ Changes
- com.ll.demo.domain.profile.profile 이하 엔티티, 컨트롤러, DTO, 서비스 파일 추가



## 📷 스크린샷 (선택)
.


## 💬 리뷰 요구사항 (선택)
일단 securityUser.getMember()를 통해 받은 ID로 DB를 재조회하여 수정하는 방식으로 구현했는데, 향후 DB 확장되면 성능 보완을 위해 어떻게 리팩토링할지 의견 부탁드려요!