### PR TITLE
feat: 그룹 관련 기능 완료

### DIFF
--- a/src/main/java/com/ll/demo/domain/group/group/controller/GroupController.java
+++ b/src/main/java/com/ll/demo/domain/group/group/controller/GroupController.java
@@ -1,0 +1,79 @@
+package com.ll.demo.domain.group.group.controller;
+
+import com.ll.demo.domain.group.group.dto.GroupRequest;
+import com.ll.demo.domain.group.group.dto.GroupResponse;
+import com.ll.demo.domain.group.group.service.GroupService;
+import com.ll.demo.global.security.SecurityUser;
+import com.ll.demo.domain.group.group.dto.MottoRequest;
+import com.ll.demo.domain.group.group.dto.GroupDetailResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+public class GroupController {
+    private final GroupService groupService;
+
+    // 그룹 생성
+    @PostMapping
+    public ResponseEntity<String> createGroup(@AuthenticationPrincipal SecurityUser user, @Valid @RequestBody GroupRequest req) {
+        groupService.createGroup(user.getMember(), req);
+        return ResponseEntity.ok("그룹이 생성되었습니다.");
+    }
+
+    // 내가 가입한 그룹 조회
+    @GetMapping("/me")
+    public ResponseEntity<List<GroupResponse>> getMyGroups(@AuthenticationPrincipal SecurityUser user) {
+        return ResponseEntity.ok(groupService.getMyGroups(user.getMember()));
+    }
+
+    // 그룹 초대
+    @PostMapping("/{groupId}/invite/{friendId}")
+    public ResponseEntity<String> invite(@AuthenticationPrincipal SecurityUser user, @PathVariable Long groupId, @PathVariable Long friendId) {
+        groupService.inviteFriend(user.getMember(), groupId, friendId);
+        return ResponseEntity.ok("초대가 완료되었습니다.");
+    }
+
+    // 그룹 친구 삭제
+    @DeleteMapping("/{groupId}/members/{memberId}")
+    public ResponseEntity<String> removeOrLeave(@AuthenticationPrincipal SecurityUser user, @PathVariable Long groupId, @PathVariable Long memberId) {
+        groupService.removeOrLeaveMember(user.getMember(), groupId, memberId);
+        return ResponseEntity.ok("완료되었습니다.");
+    }
+
+    // 그룹 가입 요청
+    @PostMapping("/{groupId}/join-request")
+    public ResponseEntity<String> joinRequest(@AuthenticationPrincipal SecurityUser user, @PathVariable Long groupId) {
+        groupService.requestToJoin(user.getMember(), groupId);
+        return ResponseEntity.ok("참여 요청이 발송되었습니다.");
+    }
+
+
+    @PostMapping("/join-requests/{requestId}/accept")
+    public ResponseEntity<String> acceptRequest(@AuthenticationPrincipal SecurityUser user, @PathVariable Long requestId) {
+        groupService.acceptJoinRequest(user.getMember(), requestId);
+        return ResponseEntity.ok("가입 승인이 완료되었습니다.");
+    }
+
+    // 특정 그룹 상세 조회
+    @GetMapping("/{groupId}")
+    public ResponseEntity<GroupDetailResponse> getGroupDetail(@PathVariable Long groupId) {
+        return ResponseEntity.ok(groupService.getGroupDetail(groupId));
+    }
+
+    // 그룹 메시지 수정
+    @PatchMapping("/{groupId}/motto")
+    public ResponseEntity<String> updateMotto(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable Long groupId,
+            @Valid @RequestBody MottoRequest req
+    ) {
+        groupService.updateMotto(securityUser.getMember(), groupId, req.motto());
+        return ResponseEntity.ok("성공적으로 수정되었습니다.");
+    }
+}

--- a/src/main/java/com/ll/demo/domain/group/group/dto/GroupDetailResponse.java
+++ b/src/main/java/com/ll/demo/domain/group/group/dto/GroupDetailResponse.java
@@ -1,0 +1,17 @@
+package com.ll.demo.domain.group.group.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GroupDetailResponse(
+        Long id,
+        String name,
+        String motto,
+        String leaderNickname,
+        long memberCount,
+        long totalQuoteCount, // 그룹원들 총 명언 수
+        LocalDateTime createdAt,
+        List<MemberInfo> members
+) {
+    public record MemberInfo(Long id, String nickname) {}
+}

--- a/src/main/java/com/ll/demo/domain/group/group/dto/GroupRequest.java
+++ b/src/main/java/com/ll/demo/domain/group/group/dto/GroupRequest.java
@@ -1,0 +1,9 @@
+package com.ll.demo.domain.group.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record GroupRequest(
+        @NotBlank @Size(max = 10, message = "그룹명은 10자 이하로 입력해주세요") String name,
+        @Size(max = 20, message = "좌우명은 20자 이하로 입력해주세요.") String motto
+) { }

--- a/src/main/java/com/ll/demo/domain/group/group/dto/GroupResponse.java
+++ b/src/main/java/com/ll/demo/domain/group/group/dto/GroupResponse.java
@@ -1,0 +1,9 @@
+package com.ll.demo.domain.group.group.dto;
+
+public record GroupResponse(
+        Long id,
+        String name,
+        String motto,
+        String leaderNickname,
+        long memberCount
+) { }

--- a/src/main/java/com/ll/demo/domain/group/group/dto/MottoRequest.java
+++ b/src/main/java/com/ll/demo/domain/group/group/dto/MottoRequest.java
@@ -1,0 +1,7 @@
+package com.ll.demo.domain.group.group.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record MottoRequest(
+        @Size(max = 20, message = "그룹 메시지는 20자 이하로 입력해주세요.") String motto
+) {}

--- a/src/main/java/com/ll/demo/domain/group/group/entity/Group.java
+++ b/src/main/java/com/ll/demo/domain/group/group/entity/Group.java
@@ -1,0 +1,25 @@
+package com.ll.demo.domain.group.group.entity;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.global.jpa.entity.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "groups")
+public class Group extends BaseTime {
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(length = 20) // 그룹 메시지
+    private String motto;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id")
+    private Member leader;
+}

--- a/src/main/java/com/ll/demo/domain/group/group/entity/GroupJoinRequest.java
+++ b/src/main/java/com/ll/demo/domain/group/group/entity/GroupJoinRequest.java
@@ -1,0 +1,26 @@
+package com.ll.demo.domain.group.group.entity;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.global.jpa.entity.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class GroupJoinRequest extends BaseTime {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id")
+    private Member requester;
+
+    @Enumerated(EnumType.STRING)
+    private JoinStatus status;
+
+    public void accept() { this.status = JoinStatus.ACCEPTED; }
+}

--- a/src/main/java/com/ll/demo/domain/group/group/entity/GroupMember.java
+++ b/src/main/java/com/ll/demo/domain/group/group/entity/GroupMember.java
@@ -1,0 +1,21 @@
+package com.ll.demo.domain.group.group.entity;
+
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.global.jpa.entity.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class GroupMember extends BaseTime {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/ll/demo/domain/group/group/entity/JoinStatus.java
+++ b/src/main/java/com/ll/demo/domain/group/group/entity/JoinStatus.java
@@ -1,0 +1,3 @@
+package com.ll.demo.domain.group.group.entity;
+
+public enum JoinStatus { PENDING, ACCEPTED, REJECTED }

--- a/src/main/java/com/ll/demo/domain/group/group/repository/GroupJoinRequestRepository.java
+++ b/src/main/java/com/ll/demo/domain/group/group/repository/GroupJoinRequestRepository.java
@@ -1,0 +1,15 @@
+package com.ll.demo.domain.group.group.repository;
+
+import com.ll.demo.domain.group.group.entity.Group;
+import com.ll.demo.domain.group.group.entity.GroupJoinRequest;
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.group.group.entity.JoinStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface GroupJoinRequestRepository extends JpaRepository<GroupJoinRequest, Long> {
+    // 사용자, 요청 중복 확인
+    Optional<GroupJoinRequest> findByGroupAndRequester(Group group, Member requester, JoinStatus status);
+    // 여부만 확인
+    boolean existsByGroupAndRequesterAndStatus(Group group, Member requester, JoinStatus status);
+}

--- a/src/main/java/com/ll/demo/domain/group/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/ll/demo/domain/group/group/repository/GroupMemberRepository.java
@@ -1,0 +1,16 @@
+package com.ll.demo.domain.group.group.repository;
+
+import com.ll.demo.domain.group.group.entity.Group;
+import com.ll.demo.domain.group.group.entity.GroupMember;
+import com.ll.demo.domain.member.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    long countByGroup(Group group);
+    boolean existsByGroupAndMember(Group group, Member member);
+    Optional<GroupMember> findByGroupAndMember(Group group, Member member);
+    List<GroupMember> findByMember(Member member); // 내가 가입한 그룹 조회
+    List<GroupMember> findByGroup(Group group); // 그룹 찾기
+}

--- a/src/main/java/com/ll/demo/domain/group/group/repository/GroupRepository.java
+++ b/src/main/java/com/ll/demo/domain/group/group/repository/GroupRepository.java
@@ -1,0 +1,6 @@
+package com.ll.demo.domain.group.group.repository;
+
+import com.ll.demo.domain.group.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {}

--- a/src/main/java/com/ll/demo/domain/group/group/service/GroupService.java
+++ b/src/main/java/com/ll/demo/domain/group/group/service/GroupService.java
@@ -1,0 +1,146 @@
+package com.ll.demo.domain.group.group.service;
+
+import com.ll.demo.domain.friendship.friendship.repository.FriendshipRepository;
+import com.ll.demo.domain.group.group.dto.GroupRequest;
+import com.ll.demo.domain.group.group.dto.GroupResponse;
+import com.ll.demo.domain.group.group.entity.Group;
+import com.ll.demo.domain.group.group.entity.GroupMember;
+import com.ll.demo.domain.group.group.repository.GroupMemberRepository;
+import com.ll.demo.domain.group.group.repository.GroupRepository;
+import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.member.member.repository.MemberRepository;
+import com.ll.demo.domain.group.group.entity.JoinStatus;
+import com.ll.demo.domain.group.group.entity.GroupJoinRequest;
+import com.ll.demo.domain.group.group.dto.GroupDetailResponse;
+import com.ll.demo.domain.group.group.repository.GroupJoinRequestRepository;
+import com.ll.demo.domain.group.group.dto.MottoRequest;
+import com.ll.demo.domain.quote.repository.QuoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupService {
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final GroupJoinRequestRepository groupJoinRequestRepository;
+    private final QuoteRepository quoteRepository;
+
+    public void createGroup(Member leader, GroupRequest req) {
+        Group group = Group.builder().name(req.name()).motto(req.motto()).leader(leader).build();
+        groupRepository.save(group);
+        groupMemberRepository.save(GroupMember.builder().group(group).member(leader).build());
+    }
+
+    public void inviteFriend(Member leader, Long groupId, Long friendId) {
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        if (!group.getLeader().getId().equals(leader.getId())) throw new RuntimeException("리더만 초대 가능합니다.");
+        if (groupMemberRepository.countByGroup(group) >= 5) throw new RuntimeException("최대 인원(5명)을 초과했습니다.");
+
+        Member friend = memberRepository.findById(friendId).orElseThrow();
+        // 친구 목록 중에서만 선택 가능!
+        if (!friendshipRepository.existsByMemberAndFriend(leader, friend)) {
+            throw new RuntimeException("친구인 사용자만 초대할 수 있습니다.");
+        }
+
+        groupMemberRepository.save(GroupMember.builder().group(group).member(friend).build());
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupResponse> getMyGroups(Member member) {
+        return groupMemberRepository.findByMember(member).stream()
+                .map(gm -> new GroupResponse(
+                        gm.getGroup().getId(),
+                        gm.getGroup().getName(),
+                        gm.getGroup().getMotto(),
+                        gm.getGroup().getLeader().getNickname(),
+                        groupMemberRepository.countByGroup(gm.getGroup())
+                )).toList();
+    }
+
+    public void removeOrLeaveMember(Member requester, Long groupId, Long targetId) {
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        GroupMember targetGM = groupMemberRepository.findByGroupAndMember(group, memberRepository.findById(targetId).orElseThrow()).orElseThrow();
+
+        if (group.getLeader().getId().equals(requester.getId()) || requester.getId().equals(targetId)) {
+            if (group.getLeader().getId().equals(targetId)) throw new RuntimeException("리더는 탈퇴할 수 없습니다.");
+            groupMemberRepository.delete(targetGM);
+        } else {
+            throw new RuntimeException("권한이 없습니다.");
+        }
+    }
+
+    // 그룹 가입 요청
+    public void requestToJoin(Member user, Long groupId) {
+        Group group = groupRepository.findById(groupId).orElseThrow();
+
+        if (groupMemberRepository.existsByGroupAndMember(group, user)) {
+            throw new RuntimeException("이미 그룹 멤버입니다.");
+        }
+        // 중복 가입 요청 췍
+        boolean alreadyRequested = groupJoinRequestRepository.existsByGroupAndRequesterAndStatus(
+                group, user, JoinStatus.PENDING
+        );
+        if (alreadyRequested) {
+            throw new RuntimeException("이미 가입 승인 대기 중입니다.");
+        }
+        groupJoinRequestRepository.save(GroupJoinRequest.builder()
+                .group(group).requester(user).status(JoinStatus.PENDING).build());
+    }
+
+    // +참여 요청 승인?
+    public void acceptJoinRequest(Member leader, Long requestId) {
+        GroupJoinRequest joinReq = groupJoinRequestRepository.findById(requestId).orElseThrow();
+        Group group = joinReq.getGroup();
+
+        if (!group.getLeader().getId().equals(leader.getId())) throw new RuntimeException("권한 부족");
+        if (groupMemberRepository.countByGroup(group) >= 5) throw new RuntimeException("인원 초과");
+
+        joinReq.accept();
+        groupMemberRepository.save(GroupMember.builder().group(group).member(joinReq.getRequester()).build());
+    }
+
+    // 그룹 상세 조회
+    @Transactional(readOnly = true)
+    public GroupDetailResponse getGroupDetail(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new RuntimeException("그룹을 찾을 수 없습니다."));
+
+        List<GroupMember> groupMembers = groupMemberRepository.findByGroup(group);
+        List<Member> members = groupMembers.stream().map(GroupMember::getMember).toList();
+        long totalQuoteCount = quoteRepository.countByAuthorIn(members);
+
+        List<GroupDetailResponse.MemberInfo> memberInfos = members.stream()
+                .map(m -> new GroupDetailResponse.MemberInfo(m.getId(), m.getNickname()))
+                .collect(Collectors.toList());
+
+        return new GroupDetailResponse(
+                group.getId(),
+                group.getName(),
+                group.getMotto(),
+                group.getLeader().getNickname(),
+                groupMembers.size(),
+                totalQuoteCount,
+                group.getCreateDate(),
+                memberInfos
+        );
+    }
+
+    // 그룹 메시지 수정
+    public void updateMotto(Member requester, Long groupId, String newMotto) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new RuntimeException("그룹을 찾을 수 없습니다."));
+
+        boolean isMember = groupMemberRepository.existsByGroupAndMember(group, requester);
+        if (!isMember) {
+            throw new RuntimeException("그룹 멤버만 좌우명을 수정할 수 있습니다.");
+        }
+        group.setMotto(newMotto);
+    }
+}

--- a/src/main/java/com/ll/demo/domain/quote/repository/QuoteRepository.java
+++ b/src/main/java/com/ll/demo/domain/quote/repository/QuoteRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ll.demo.domain.member.member.entity.Member;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
+
 public interface QuoteRepository extends JpaRepository<Quote, Long> {
     // 1. 나의 명언 조회 (최신순)
     List<Quote> findAllByAuthorIdOrderByCreateDateDesc(Long authorId);
@@ -22,4 +24,7 @@ public interface QuoteRepository extends JpaRepository<Quote, Long> {
     long countByAuthor(Member author);
     @Query("select ql.quote from QuoteLike ql where ql.member.id = :memberId order by ql.id desc")
     List<Quote> findQuotesLikedByMember(@Param("memberId") Long memberId);
+
+    // 그룹원 리스트 > 명언 총 개수
+    long countByAuthorIn(Collection<Member> authors);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #37 


## 📢 작업 내용 
- 그룹 생성
- 내가 가입한 그룹들 조회
- 친구 한정 그룹 초대
- 그룹 가입 요청 (+그룹 가입 승인)
- 그룹 상세 페이지 (Quote 관련 코드 추가)
- 그룹 메시지 작성 및 수정
- 그룹원 삭제 및 그룹원 탈퇴

## ✨ Changes
- QuoteRepository.java으로 그룹에 속한 멤버 리스트를 추출하여 이들이 작성한 전체 명언 수를 집계하는 countByAuthorIn 로직 추가
- GroupJoinRequestRepository으로 이미 가입 대기(PENDING) 상태면 중복 신청 차단
- findById를 통한 영속성 컨텍스트 처리로 데이터 무결성 보장


## 📷 스크린샷 (선택)
.


## 💬 리뷰 요구사항 (선택)
.