### PR TITLE
feat: 계정 수정, 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
+    implementation 'javax.persistence:javax.persistence-api:2.2'
     implementation 'com.google.genai:google-genai:0.4.0'
 }
 //

--- a/src/main/java/com/ll/demo/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/demo/domain/member/member/entity/Member.java
@@ -1,7 +1,7 @@
 package com.ll.demo.domain.member.member.entity;
 
 import static lombok.AccessLevel.PROTECTED;
-
+import com.ll.demo.domain.member.member.type.Gender;
 import com.ll.demo.global.jpa.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,6 +17,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 @Entity
 @Table(name = "members")
@@ -68,4 +70,8 @@ public class Member extends BaseTime {
         }
         return this.email.split("@")[0]; // 예: test@naver.com -> test
     }
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private Gender gender;
 }

--- a/src/main/java/com/ll/demo/domain/member/member/type/Gender.java
+++ b/src/main/java/com/ll/demo/domain/member/member/type/Gender.java
@@ -1,0 +1,16 @@
+package com.ll.demo.domain.member.member.type;
+
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    MALE("남성"),
+    FEMALE("여성"),
+    ETC("선택하지 않음");
+
+    private final String value;
+
+    Gender(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/ll/demo/domain/profile/profile/controller/ProfileController.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/controller/ProfileController.java
@@ -1,13 +1,14 @@
 package com.ll.demo.domain.profile.profile.controller;
 
+import com.ll.demo.domain.profile.profile.dto.AccountUpdateRequest;
 import com.ll.demo.domain.member.member.entity.Member;
 import com.ll.demo.domain.profile.profile.dto.ProfileResponse;
 import com.ll.demo.domain.profile.profile.dto.ProfileUpdateRequest;
 import com.ll.demo.domain.profile.profile.service.ProfileService;
 import com.ll.demo.global.security.SecurityUser;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,5 +31,25 @@ public class ProfileController {
             @Valid @RequestBody ProfileUpdateRequest request
     ) {
         return ResponseEntity.ok(profileService.updateProfile(securityUser.getMember(), request));
+    }
+
+
+    // 계정 정보 수정
+    @PutMapping("/account")
+    public ResponseEntity<String> updateAccount(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @Valid @RequestBody AccountUpdateRequest request
+    ) {
+        profileService.updateAccountInfo(securityUser.getMember(), request);
+        return ResponseEntity.ok("계정 정보가 수정되었습니다.");
+    }
+
+    // 계정 삭제
+    @DeleteMapping("/account")
+    public ResponseEntity<String> deleteAccount(
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        profileService.deleteAccount(securityUser.getMember());
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/ll/demo/domain/profile/profile/dto/AccountUpdateRequest.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/dto/AccountUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.ll.demo.domain.profile.profile.dto;
+
+import com.ll.demo.domain.member.member.type.Gender;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AccountUpdateRequest(
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "올바른 이메일 주소를 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "출생년도는 필수 입력 항목입니다.")
+        @Size(min = 4, max = 4, message = "출생년도는 4자리로 입력해주세요.")
+        String birthYear,
+
+        @NotNull(message = "성별을 선택해주세요.")
+        Gender gender
+) {}

--- a/src/main/java/com/ll/demo/domain/profile/profile/service/ProfileService.java
+++ b/src/main/java/com/ll/demo/domain/profile/profile/service/ProfileService.java
@@ -1,12 +1,12 @@
 package com.ll.demo.domain.profile.profile.service;
 
 import com.ll.demo.domain.member.member.entity.Member;
-import com.ll.demo.domain.member.member.entity.Member;
 import com.ll.demo.domain.member.member.repository.MemberRepository;
 import com.ll.demo.domain.quote.repository.QuoteRepository;
 import com.ll.demo.domain.friendship.friendship.repository.FriendshipRepository;
 import com.ll.demo.domain.profile.profile.dto.ProfileResponse;
 import com.ll.demo.domain.profile.profile.dto.ProfileUpdateRequest;
+import com.ll.demo.domain.profile.profile.dto.AccountUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,5 +44,30 @@ public class ProfileService {
         // memberRepository.save(persistentMember);
 
         return getMyProfile(persistentMember);
+    }
+
+    // 계정 정보 수정
+    public void updateAccountInfo(Member member, AccountUpdateRequest request) {
+        Member persistentMember = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        // 이메일 중복 체크
+        if (!persistentMember.getEmail().equals(request.email())) {
+            memberRepository.findByEmail(request.email()).ifPresent(m -> {
+                throw new RuntimeException("이미 사용 중인 이메일입니다.");
+            });
+        }
+
+        persistentMember.setEmail(request.email());
+        persistentMember.setBirthYear(request.birthYear());
+        persistentMember.setGender(request.gender()); // 성별 업데이트
+    }
+
+    // 계정 삭제
+    public void deleteAccount(Member member) {
+        Member persistentMember = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        memberRepository.delete(persistentMember);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #40 


## 📢 작업 내용 
- 계정 정보 (이메일, 생년, 성별) 수정
- 계정 삭제

## ✨ Changes
- Member 엔티티에 Gender 필드 추가
- 이메일 수정 시 기존 회원과의 중복 여부 검증 > 데이터 무결성 보장
- SecurityUser에서 추출한 ID로 DB를 재조회하여 영속성 보장



## 📷 스크린샷 (선택)
.


## 💬 리뷰 요구사항 (선택)
- 회원 탈퇴 시 명언이나 그룹 등 연관 테이블의 데이터를 즉시 삭제할지, 혹은 Soft Delete 처리를 할지 추후에 논의하면 좋을 것 같습니다!