### PR TITLE
Fix/home search friends

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'com.google.genai:google-genai:0.4.0'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.security:spring-security-core'
 }
 //
 //tasks.named('test') {

--- a/src/main/java/com/ll/demo/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/com/ll/demo/domain/archive/controller/ArchiveController.java
@@ -21,26 +21,25 @@ public class ArchiveController {
 
     private final QuoteService quoteService;
 
+    // 날짜별 명언 조회
     @GetMapping
     public ResponseEntity<List<QuoteResponse>> getQuotesByDate(
             @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
     ) {
-        // Service가 DTO를 주니까 바로 리턴하면 됨!
         List<QuoteResponse> result = quoteService.findQuotesByDate(date);
         return ResponseEntity.ok(result);
     }
 
+    // 내가 작성한 명언 목록
     @GetMapping("/me")
     public ResponseEntity<List<QuoteResponse>> getMyQuotes(
             @AuthenticationPrincipal SecurityUser user
     ) {
-        // 여기도 바로 리턴!
         List<QuoteResponse> result = quoteService.findMyQuotes(user.getMember().getId());
         return ResponseEntity.ok(result);
     }
 
-    // 3. 좋아요한 글 (내가 하트 누른 글 목록)
-    // GET /api/archives/likes
+    // 내가 좋아요한 명언 목록 조회
     @GetMapping("/likes")
     public ResponseEntity<List<QuoteResponse>> getLikedQuotes(
             @AuthenticationPrincipal SecurityUser user

--- a/src/main/java/com/ll/demo/domain/group/group/controller/GroupController.java
+++ b/src/main/java/com/ll/demo/domain/group/group/controller/GroupController.java
@@ -34,7 +34,11 @@ public class GroupController {
 
     // 그룹 초대
     @PostMapping("/{groupId}/invite/{friendId}")
-    public ResponseEntity<String> invite(@AuthenticationPrincipal SecurityUser user, @PathVariable Long groupId, @PathVariable Long friendId) {
+    public ResponseEntity<String> invite(
+            @AuthenticationPrincipal SecurityUser user,
+            @PathVariable Long groupId,
+            @PathVariable Long friendId
+    ) {
         groupService.inviteFriend(user.getMember(), groupId, friendId);
         return ResponseEntity.ok("초대가 완료되었습니다.");
     }

--- a/src/main/java/com/ll/demo/domain/group/group/dto/GroupSearchResponse.java
+++ b/src/main/java/com/ll/demo/domain/group/group/dto/GroupSearchResponse.java
@@ -1,0 +1,23 @@
+package com.ll.demo.domain.group.group.dto;
+
+import com.ll.demo.domain.group.group.entity.Group;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupSearchResponse {
+    private Long id;
+    private String name;
+    private String motto;
+    private String leaderNickname;
+
+    public static GroupSearchResponse of(Group group) {
+        return GroupSearchResponse.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .motto(group.getMotto())
+                .leaderNickname(group.getLeader().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/ll/demo/domain/group/group/dto/SearchCombinedResponse.java
+++ b/src/main/java/com/ll/demo/domain/group/group/dto/SearchCombinedResponse.java
@@ -1,0 +1,13 @@
+package com.ll.demo.domain.member.member.dto;
+
+import com.ll.demo.domain.group.group.dto.GroupSearchResponse;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class SearchCombinedResponse {
+    private List<MemberSearchResponse> members;
+    private List<GroupSearchResponse> groups;
+}

--- a/src/main/java/com/ll/demo/domain/group/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/ll/demo/domain/group/group/repository/GroupMemberRepository.java
@@ -4,6 +4,8 @@ import com.ll.demo.domain.group.group.entity.Group;
 import com.ll.demo.domain.group.group.entity.GroupMember;
 import com.ll.demo.domain.member.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +15,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     Optional<GroupMember> findByGroupAndMember(Group group, Member member);
     List<GroupMember> findByMember(Member member); // 내가 가입한 그룹 조회
     List<GroupMember> findByGroup(Group group); // 그룹 찾기
+    // 그룹 이름 키워드가 포함된 그룹 멤버
+    @Query("SELECT gm.member FROM GroupMember gm JOIN gm.group g WHERE LOWER(g.name) LIKE LOWER(CONCAT('%', :groupNameKeyword, '%'))")
+    List<Member> findMembersByGroupNameContaining(@Param("groupNameKeyword") String groupNameKeyword);
 }

--- a/src/main/java/com/ll/demo/domain/group/group/repository/GroupRepository.java
+++ b/src/main/java/com/ll/demo/domain/group/group/repository/GroupRepository.java
@@ -2,5 +2,9 @@ package com.ll.demo.domain.group.group.repository;
 
 import com.ll.demo.domain.group.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
-public interface GroupRepository extends JpaRepository<Group, Long> {}
+public interface GroupRepository extends JpaRepository<Group, Long> {
+    //  그룹 자체를 조회
+    List<Group> findByNameContainingIgnoreCase(String nameKeyword);
+}

--- a/src/main/java/com/ll/demo/domain/member/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/ll/demo/domain/member/member/controller/ApiV1MemberController.java
@@ -11,6 +11,8 @@ import com.ll.demo.global.exceptions.GlobalException;
 import com.ll.demo.global.rsData.RsData;
 import com.ll.demo.global.security.AuthTokenService;
 import com.ll.demo.standard.rq.Rq;
+import com.ll.demo.global.security.SecurityUser;
+import com.ll.demo.domain.member.member.dto.SearchCombinedResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -22,7 +24,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -96,5 +100,21 @@ public class ApiV1MemberController {
         response.addCookie(passwordCookie);
 
         return RsData.of("200-2", "로그아웃 성공");
+    }
+
+    //회원 및 그룹 통합 검색
+    @GetMapping("/search")
+    public ResponseEntity<SearchCombinedResponse> searchMembers(
+            @RequestParam(value = "keyword", required = true) String keyword,
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        if (securityUser == null) {
+            throw new GlobalException("401", "로그인이 필요합니다.");
+        }
+
+        Long currentMemberId = securityUser.getMember().getId();
+
+        SearchCombinedResponse response = memberService.searchCombined(keyword, currentMemberId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ll/demo/domain/member/member/dto/FriendResponse.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/FriendResponse.java
@@ -1,6 +1,7 @@
 package com.ll.demo.domain.member.member.dto;
 
 import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.friendship.friendship.entity.Friendship;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,14 +11,21 @@ public class FriendResponse {
     private Long id;
     private String nickname;
     private String profileImage;
-    private String email;
+    private String introduction;
+    private boolean isGroupMember;
 
-    public static FriendResponse of(Member member) {
+    public static FriendResponse of(Member friend, boolean isGroupMember) {
         return FriendResponse.builder()
-                .id(member.getId())
-                .nickname(member.getNickname())
-                .profileImage(member.getProfileImage())
-                .email(member.getEmail())
+                .id(friend.getId())
+                .nickname(friend.getNickname())
+                .profileImage(friend.getProfileImage())
+                .introduction(friend.getIntroduction())
+                .isGroupMember(isGroupMember)
                 .build();
+    }
+
+    public static FriendResponse of(Friendship friendship) {
+        Member friend = friendship.getFriend();
+        return FriendResponse.of(friend, false); // 일단 false
     }
 }

--- a/src/main/java/com/ll/demo/domain/member/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/MemberSearchResponse.java
@@ -4,7 +4,6 @@ import com.ll.demo.domain.member.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
-
 @Getter
 @Builder
 public class MemberSearchResponse {
@@ -12,13 +11,15 @@ public class MemberSearchResponse {
     private String nickname;
     private String profileImage;
     private String email;
-    // 추후 친구 정보 추가?
+    private String introduction;
+
     public static MemberSearchResponse of(Member member) {
         return MemberSearchResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
                 .profileImage(member.getProfileImage())
                 .email(member.getEmail())
+                .introduction(member.getIntroduction())
                 .build();
     }
 }

--- a/src/main/java/com/ll/demo/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/ll/demo/domain/member/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.ll.demo.domain.member.member.service;
 
 import com.ll.demo.domain.member.member.entity.Member;
 import com.ll.demo.domain.member.member.repository.MemberRepository;
+import com.ll.demo.domain.group.group.repository.GroupMemberRepository;
 import com.ll.demo.global.exceptions.GlobalException;
 import com.ll.demo.global.rsData.RsData;
 import java.util.Optional;
@@ -14,10 +15,18 @@ import com.ll.demo.domain.member.member.dto.ProfileUpdateRequest;
 import com.ll.demo.domain.member.member.dto.MemberSearchResponse;
 import com.ll.demo.domain.member.member.dto.FriendResponse;
 import com.ll.demo.domain.friendship.friendship.repository.FriendshipRepository;
+import com.ll.demo.domain.friendship.friendship.entity.Friendship;
+import com.ll.demo.domain.group.group.repository.GroupMemberRepository;
+import com.ll.demo.domain.group.group.repository.GroupRepository;
+import com.ll.demo.domain.group.group.entity.Group;
+import com.ll.demo.domain.group.group.dto.GroupSearchResponse;
+import com.ll.demo.domain.member.member.dto.SearchCombinedResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.Collections;
-import com.ll.demo.domain.friendship.friendship.entity.Friendship;
+import java.util.HashSet;
+import java.util.Set;
+
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +36,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final FriendshipRepository friendshipRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupRepository groupRepository;
 
     // 이메일로 회원 조회
     @Transactional(readOnly = true)
@@ -102,21 +113,55 @@ public class MemberService {
         member.setIntroduction(request.getIntroduction());
         member.setProfileImage(newProfileImageUrl);
     }
-    // 닉네임 or 이메일로 회원 검색
-    // 친구 목록 조회 + 친구 검색
-    public List<MemberSearchResponse> searchMembers(String keyword, Long currentMemberId) {
 
-        List<Member> members = memberRepository
+//    // 닉네임, 이메일, 그룹명으로 회원 검색
+//    public List<MemberSearchResponse> searchMembers(String keyword, Long currentMemberId) {
+//        List<Member> membersByNicknameOrEmail = memberRepository
+//                .searchMembersByNicknameOrEmailUsername(keyword);
+//        List<Member> membersByGroupName = groupMemberRepository
+//                .findMembersByGroupNameContaining(keyword);
+//        Set<Member> combinedMembers = new HashSet<>(membersByNicknameOrEmail);
+//        combinedMembers.addAll(membersByGroupName);
+//
+//        List<Member> filteredMembers = combinedMembers.stream()
+//                .filter(m -> !m.getId().equals(currentMemberId))
+//                .toList();
+//
+//        return filteredMembers.stream()
+//                .map(MemberSearchResponse::of)
+//                .toList();
+//    }
+
+    // 회원 및 그룹 검색
+    public SearchCombinedResponse searchCombined(String keyword, Long currentMemberId) {
+        // 닉네임or이메일로 검색
+        List<Member> membersByNicknameOrEmail = memberRepository
                 .searchMembersByNicknameOrEmailUsername(keyword);
 
-        List<Member> filteredMembers = members.stream()
-                .filter(m -> !m.getId().equals(currentMemberId))
-                .toList();
+        // 그룹명으로 그룹 멤버 검색
+        List<Member> membersByGroupName = groupMemberRepository
+                .findMembersByGroupNameContaining(keyword);
 
-        return filteredMembers.stream()
+        Set<Member> combinedMembers = new HashSet<>(membersByNicknameOrEmail);
+        combinedMembers.addAll(membersByGroupName);
+
+        List<MemberSearchResponse> memberResponses = combinedMembers.stream()
+                .filter(m -> !m.getId().equals(currentMemberId))
                 .map(MemberSearchResponse::of)
                 .toList();
+        // 그룹 자체
+        List<Group> groups = groupRepository.findByNameContainingIgnoreCase(keyword);
+
+        List<GroupSearchResponse> groupResponses = groups.stream()
+                .map(GroupSearchResponse::of)
+                .toList();
+
+        return SearchCombinedResponse.builder()
+                .members(memberResponses)
+                .groups(groupResponses)
+                .build();
     }
+
 
     // 친구 목록 조회
     public List<FriendResponse> getFriendList(Long memberId) {
@@ -126,8 +171,10 @@ public class MemberService {
         List<Friendship> friendships = friendshipRepository.findAllByMember(member);
 
         return friendships.stream()
-                .map(Friendship::getFriend)
-                .map(FriendResponse::of)
+                .map(friendship -> {
+                    Member friend = friendship.getFriend();
+                    return FriendResponse.of(friend, false);
+                })
                 .toList();
     }
 

--- a/src/main/java/com/ll/demo/domain/quote/dto/MyQuoteResponse.java
+++ b/src/main/java/com/ll/demo/domain/quote/dto/MyQuoteResponse.java
@@ -1,0 +1,19 @@
+package com.ll.demo.domain.quote.dto;
+
+import com.ll.demo.domain.quote.entity.Quote;
+
+public record MyQuoteResponse(
+        String content,
+        String groupName,
+        String authorNickname,
+        String birthYear
+) {
+    public static MyQuoteResponse from(Quote quote, String groupName) {
+        return new MyQuoteResponse(
+                quote.getContent(),
+                groupName,
+                quote.getAuthor().getNickname(),
+                quote.getAuthor().getBirthYear()
+        );
+    }
+}

--- a/src/main/java/com/ll/demo/domain/quote/dto/QuoteDetailResponse.java
+++ b/src/main/java/com/ll/demo/domain/quote/dto/QuoteDetailResponse.java
@@ -1,0 +1,48 @@
+package com.ll.demo.domain.quote.dto;
+
+import com.ll.demo.domain.quote.entity.Quote;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record QuoteDetailResponse(
+        Long id,
+        String content,
+        List<String> taggedNicknames,
+        String authorNickname,
+        String authorProfileImage,
+        String authorIntroduction,
+        String timeAgo,
+        boolean isLiked,
+        boolean isFriendQuote
+) {
+    public static QuoteDetailResponse from(
+            Quote quote,
+            List<String> taggedNicknames,
+            boolean isLiked,
+            boolean isFriend
+    ) {
+        Duration duration = Duration.between(quote.getCreateDate(), LocalDateTime.now());
+        String timeAgo = formatDuration(duration);
+
+        return new QuoteDetailResponse(
+                quote.getId(),
+                quote.getContent(),
+                taggedNicknames,
+                quote.getAuthor().getNickname(),
+                quote.getAuthor().getProfileImage(),
+                quote.getAuthor().getIntroduction(),
+                timeAgo,
+                isLiked,
+                isFriend
+        );
+    }
+
+    private static String formatDuration(Duration duration) {
+        long hours = duration.toHours();
+        if (hours > 0) return hours + "시간 전";
+        long minutes = duration.toMinutes();
+        if (minutes > 0) return minutes + "분 전";
+        return "방금 전";
+    }
+}

--- a/src/main/java/com/ll/demo/domain/quote/dto/QuoteListDto.java
+++ b/src/main/java/com/ll/demo/domain/quote/dto/QuoteListDto.java
@@ -1,0 +1,8 @@
+package com.ll.demo.domain.quote.dto;
+
+import java.util.List;
+
+public record QuoteListDto(
+        List<MyQuoteResponse> myQuotes,
+        List<QuoteDetailResponse> otherQuotes
+) {}

--- a/src/main/java/com/ll/demo/domain/quote/repository/QuoteRepository.java
+++ b/src/main/java/com/ll/demo/domain/quote/repository/QuoteRepository.java
@@ -1,20 +1,24 @@
 package com.ll.demo.domain.quote.repository;
 
 import com.ll.demo.domain.quote.entity.Quote;
-import io.lettuce.core.dynamic.annotation.Param;
+// import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.ll.demo.domain.member.member.entity.Member;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface QuoteRepository extends JpaRepository<Quote, Long> {
-    // 1. 나의 명언 조회 (최신순)
+    // 나의 명언 조회
     List<Quote> findAllByAuthorIdOrderByCreateDateDesc(Long authorId);
 
-    // 2. 특정 날짜의 전체 명언 조회 (오늘 0시 ~ 오늘 23시 59분 사이)
+    // 특정 날짜의 전체 명언 조회
     List<Quote> findAllByCreateDateBetweenOrderByCreateDateDesc(LocalDateTime start, LocalDateTime end);
 
     // 1일 1명언 체크용
@@ -27,4 +31,15 @@ public interface QuoteRepository extends JpaRepository<Quote, Long> {
 
     // 그룹원 리스트 > 명언 총 개수
     long countByAuthorIn(Collection<Member> authors);
+
+    // 로그인한 사용자가 작성한 거 제외하고 모든 명언 조회
+    @Query("SELECT q FROM Quote q WHERE q.author.id <> :userId OR :userId IS NULL")
+    List<Quote> findAllExcludingUser(@Param("userId") Long userId, Sort sort);
+
+    // 날짜 범위 필터링
+    @Query("SELECT q FROM Quote q WHERE q.createDate >= :startDate AND q.createDate < :endDate ORDER BY q.createDate DESC")
+    List<Quote> findAllByDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    // 내가 작성한 글 모두 조회
+    List<Quote> findAllByAuthorId(Long authorId);
 }

--- a/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/ll/demo/domain/quote/service/QuoteService.java
@@ -15,16 +15,29 @@ import com.ll.demo.domain.quote.repository.QuoteRepository;
 import com.ll.demo.domain.quote.repository.QuoteTagRepository;
 import com.ll.demo.domain.quote.repository.QuoteTagRequestRepository;
 import com.ll.demo.global.exceptions.GlobalException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
+import com.ll.demo.global.security.SecurityUser;
+import com.ll.demo.domain.friendship.friendship.repository.FriendshipRepository;
+import com.ll.demo.domain.group.group.entity.GroupMember;
+import com.ll.demo.domain.group.group.repository.GroupMemberRepository;
+import com.ll.demo.domain.quote.dto.MyQuoteResponse;
+import com.ll.demo.domain.quote.dto.QuoteDetailResponse;
+import com.ll.demo.domain.quote.dto.QuoteListDto;
+import com.ll.demo.domain.quote.dto.QuoteResponse;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,11 +46,12 @@ public class QuoteService {
 
     private final QuoteRepository quoteRepository;
     private final QuoteLikeRepository quoteLikeRepository;
-    private final MemberRepository memberRepository; // ★ [수정] 이게 없어서 에러가 났었습니다!
+    private final MemberRepository memberRepository;
     private final QuoteTagRequestRepository quoteTagRequestRepository;
     private final QuoteTagRepository quoteTagRepository;
     private final NotificationService notificationService;
-
+    private final FriendshipRepository friendshipRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     // 명언 작성 (저장)
     @Transactional
@@ -117,26 +131,98 @@ public class QuoteService {
                 .ifPresent(quoteLikeRepository::delete);
     }
 
-    // 전체 명언 목록 조회 (단순 리스트)
-    public List<QuoteResponse> getQuoteList() {
-        List<Quote> quotes = quoteRepository.findAll(Sort.by(Sort.Direction.DESC, "createDate"));
-        return quotes.stream()
+    // 명언 목록 조회 - 날짜 필터링+필요정보
+    public QuoteListDto getQuoteList(Member currentUser, LocalDate date) {
+
+        LocalDateTime startDate = date.atStartOfDay();
+        LocalDateTime endDate = date.plusDays(1).atStartOfDay();
+
+        List<Quote> quotes = quoteRepository.findAllByDateRange(startDate, endDate);
+        List<MyQuoteResponse> myQuotes = quotes.stream()
+                .filter(q -> q.getAuthor().getId().equals(currentUser.getId()))
+                .map(q -> {
+                    String groupName = getQuoteGroupName(q);
+                    return MyQuoteResponse.from(q, groupName);
+                })
+                .toList();
+        List<QuoteDetailResponse> otherQuotes = quotes.stream()
+                .filter(q -> !q.getAuthor().getId().equals(currentUser.getId()))
+                .map(q -> {
+                    boolean isLiked = quoteLikeRepository.existsByQuoteAndMember(q, currentUser);
+                    boolean isFriend = friendshipRepository.existsByMemberAndFriend(currentUser, q.getAuthor());
+                    List<String> taggedNicknames = quoteTagRepository.findAllByQuote(q).stream()
+                            .map(qt -> qt.getMember().getNickname())
+                            .collect(Collectors.toList());
+                    return QuoteDetailResponse.from(q, taggedNicknames, isLiked, isFriend);
+                })
+                .toList();
+
+        return new QuoteListDto(myQuotes, otherQuotes);
+    }
+
+    // 명언 작성자가 속한 그룹
+    private String getQuoteGroupName(Quote quote) {
+        List<GroupMember> groupMembers = groupMemberRepository.findByMember(quote.getAuthor());
+        if (!groupMembers.isEmpty()) {
+            return groupMembers.get(0).getGroup().getName();
+        }
+        return "아직 그룹이 없습니다.";
+    }
+
+    // 로그인한 사용자
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+            return null; // 인증되지 않은 사용자
+        }
+
+        if (authentication.getPrincipal() instanceof SecurityUser securityUser) {
+            return securityUser.getMember().getId();
+        }
+
+        return null;
+    }
+
+    // 명언에 태그 요청하는 메서드
+    @Transactional
+    public void tagRequestQuote(Member requester, Long quoteId) {
+        Quote quote = quoteRepository.findById(quoteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "명언을 찾을 수 없습니다."));
+
+        if (quoteTagRequestRepository.existsByQuoteAndRequester(quote, requester)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 해당 글에 태그 요청을 하셨습니다.");
+        }
+
+        if (requester.getId().equals(quote.getAuthor().getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "본인 글에는 태그 요청을 할 수 없습니다.");
+        }
+
+        QuoteTagRequest tagRequest = QuoteTagRequest.builder()
+                .quote(quote)
+                .requester(requester)
+                .build();
+
+        quoteTagRequestRepository.save(tagRequest);
+    }
+
+    public List<QuoteResponse> findMyQuotes(Long memberId) {
+        List<Quote> myQuotes = quoteRepository.findAllByAuthorId(memberId);
+
+        return myQuotes.stream()
                 .map(QuoteResponse::from)
-                .toList();
+                .collect(Collectors.toList());
     }
 
+    // 내가 좋아요 누른 명언 조회
+    public List<QuoteResponse> findLikedQuotes(Long memberId) {
+        List<Quote> likedQuotes = quoteRepository.findQuotesLikedByMember(memberId);
 
-    // 1. 나의 명언 목록 가져오기
-    public List<QuoteResponse> findMyQuotes(Long authorId) {
-        List<Quote> quotes = quoteRepository.findAllByAuthorIdOrderByCreateDateDesc(authorId);
-
-        // ★ 여기서(Service 내부) 변환해야 DB 연결이 유지된 상태로 닉네임을 가져올 수 있음
-        return quotes.stream()
-                .map(QuoteResponse::new)
-                .toList();
+        return likedQuotes.stream()
+                .map(QuoteResponse::from)
+                .collect(Collectors.toList());
     }
 
-    // 2. 특정 날짜의 전체 명언 가져오기
+    // 특정 날짜의 전체 명언
     public List<QuoteResponse> findQuotesByDate(LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
@@ -148,17 +234,31 @@ public class QuoteService {
                 .toList();
     }
 
-
-    // [추가] 좋아요한 글 목록 조회
-    public List<QuoteResponse> findLikedQuotes(Long memberId) {
-        // 1. DB에서 내가 좋아요한 Quote 목록 조회
-        List<Quote> likedQuotes = quoteRepository.findQuotesLikedByMember(memberId);
-
-        // 2. DTO로 변환
-        return likedQuotes.stream()
-                .map(QuoteResponse::new)
-                .toList();
+    // 태그 요청
+    @Transactional
+    public void requestTagToQuote(Long quoteId, Member requester) {
+        Quote quote = quoteRepository.findById(quoteId)
+                .orElseThrow(() -> new GlobalException("404", "해당 명언을 찾을 수 없습니다."));
+        if (quote.getAuthor().getId().equals(requester.getId())) {
+            throw new GlobalException("400", "자신이 작성한 글에는 태그 요청을 할 수 없습니다.");
+        }
+        if (quoteTagRequestRepository.existsByQuoteAndRequester(quote, requester)) {
+            throw new GlobalException("409", "이미 해당 명언에 태그 요청을 하였습니다.");
+        }
+        QuoteTagRequest tagRequest = QuoteTagRequest.builder()
+                .quote(quote)
+                .requester(requester)
+                .build();
+        quoteTagRequestRepository.save(tagRequest);
     }
+
+//    // 좋아요한 글 목록 조회 - 이전 버전
+//    public List<QuoteResponse> findLikedQuotes(Long memberId) {
+//        List<Quote> likedQuotes = quoteRepository.findQuotesLikedByMember(memberId);
+//        return likedQuotes.stream()
+//                .map(QuoteResponse::new)
+//                .toList();
+//    }
 
     // 태그 수정 기능
     @Transactional
@@ -166,15 +266,15 @@ public class QuoteService {
         Quote quote = quoteRepository.findById(quoteId)
                 .orElseThrow(() -> new RuntimeException("명언을 찾을 수 없습니다."));
 
-        // 1. 작성자 본인 확인 (본인 글만 태그 수정 가능)
+        // 작성자 본인 확인
         if (!quote.getAuthor().getId().equals(authorId)) {
             throw new RuntimeException("수정 권한이 없습니다.");
         }
 
-        // 2. 기존 태그 싹 지우기 (초기화)
+        // 기존 태그 초기화
         quoteTagRepository.deleteAllByQuote(quote);
 
-        // 3. 새로운 태그 저장 및 알림 발송
+        // 새로운 태그 저장 및 알림 발송
         if (taggedMemberIds != null && !taggedMemberIds.isEmpty()) {
             for (Long memberId : taggedMemberIds) {
                 Member taggedMember = memberRepository.findById(memberId)

--- a/src/main/java/com/ll/demo/domain/settings/controller/SettingsController.java
+++ b/src/main/java/com/ll/demo/domain/settings/controller/SettingsController.java
@@ -8,16 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import com.ll.demo.domain.member.member.dto.FriendResponse;
 import com.ll.demo.domain.member.member.entity.Member;
+import com.ll.demo.domain.member.member.dto.SearchCombinedResponse; // 응답 dto 교체
 import java.util.List;
 import org.springframework.web.bind.annotation.RequestParam;
-import com.ll.demo.domain.member.member.dto.MemberSearchResponse;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
-
-
 @RestController
 @RequestMapping("/api/settings")
 @RequiredArgsConstructor
@@ -48,15 +45,14 @@ public class SettingsController {
         return ResponseEntity.ok().build();
     }
 
-    // 친구 검색 - !재검토 필요! 그룹명으로도 검색 가능하도록 service 수정
+    // 친구 및 그룹 통합검색
     @GetMapping("/search")
-    public ResponseEntity<List<MemberSearchResponse>> searchMembers(
+    public ResponseEntity<SearchCombinedResponse> searchMembers(
             @RequestParam(name = "keyword") String keyword,
             @AuthenticationPrincipal SecurityUser securityUser
     ) {
         Long memberId = securityUser.getMember().getId();
-        List<MemberSearchResponse> response = memberService.searchMembers(keyword, memberId);
-
+        SearchCombinedResponse response = memberService.searchCombined(keyword, memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/ll/demo/global/jpa/entity/BaseTime.java
+++ b/src/main/java/com/ll/demo/global/jpa/entity/BaseTime.java
@@ -11,8 +11,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@MappedSuperclass
 @Getter
+@MappedSuperclass
 @Setter(AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTime extends BaseEntity {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #46 


## 📢 작업 내용 
- 날짜 기반 전체 명언 필터링
- 나/다른 친구들 명언 분리 리턴
- 전체 명언에 상세 정보 추가
- 회원/그룹 통합 검색 완성
- 모든 그룹 멤버가 그룹 초대 가능하도록 변경\
- 친구 목록 상세 정보 추가

## ✨ Changes
- QuoteService.getQuoteList 메서드에 LocalDate 추가
- QuoteRepository.findAllByDateRange 쿼리 사용 > 날짜별 명언 필터링
- QuoteListDto에서 myQuotes / otherQuotes 분리
- QuoteDetailResponse에 필요 필드를 모두 포함
- MemberService.searchCombined() 메서드로 검색 로직 통합
- MemberRepository > 닉네임/이메일 검색, GroupMemberRepository > 그룹 멤버 검색, GroupRepository > 그룹 검색
- MemberSearchResponse에 필요 필드를 모두 포함
- GroupService.inviteFriend 메서드에서 group.getLeader().equals(requester) 체크 로직 제거
- MemberService.getFriendList 메서드에서 필요 필드를 모두 포함


## 📷 스크린샷 (선택)
- .



## 💬 리뷰 요구사항 (선택)
- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
