### PR TITLE
fix: 회원가입 응답에 access token 추가

### DIFF
--- a/src/main/java/com/ll/demo/domain/member/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/ll/demo/domain/member/member/controller/ApiV1MemberController.java
@@ -38,6 +38,7 @@ public class ApiV1MemberController {
     private final Rq rq;
     private final AuthTokenService authTokenService;
 
+    // 회원가입
     @PostMapping("/signup")
     public RsData<MemberJoinRespBody> join(@RequestBody @Valid MemberJoinReqBody reqBody) {
         Integer birthYear = Integer.parseInt(reqBody.getBirthYear());
@@ -49,8 +50,11 @@ public class ApiV1MemberController {
         );
 
         Member memberEntity = joinRs.getData();
+
+        // 토큰 생성하고 리턴하도록 수정
+        String accessToken = authTokenService.genToken(memberEntity, AppConfig.getAccessTokenExpirationSec());
         MemberDto memberDto = MemberDto.of(memberEntity);
-        return joinRs.newDataOf(new MemberJoinRespBody(memberDto));
+        return joinRs.newDataOf(new MemberJoinRespBody(memberDto, accessToken));
     }
 
     @Getter

--- a/src/main/java/com/ll/demo/domain/member/member/dto/MemberJoinRespBody.java
+++ b/src/main/java/com/ll/demo/domain/member/member/dto/MemberJoinRespBody.java
@@ -7,5 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MemberJoinRespBody {
 
-    private MemberDto item;  // 엔티티>DTO로 변경
+    private MemberDto item;
+    private String accessToken;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #2


## 📢 작업 내용 
- 회원가입 응답에 access token 추가


## ✨ Changes
- MemberJoinRespBody DTO에 accessToken 필드 추가
- ApiV1MemberController의 join 메서드에 토큰 생성하여 위 DTO에 담아 반환하는 로직 추가



## 📷 스크린샷 (선택)
.



## 💬 리뷰 요구사항 (선택)
.
